### PR TITLE
Send without view or html

### DIFF
--- a/src/MailerSendTrait.php
+++ b/src/MailerSendTrait.php
@@ -22,6 +22,10 @@ trait MailerSendTrait
                 $message->addPart(json_encode($mailersendData, JSON_THROW_ON_ERROR),
                     MailerSendTransport::MAILERSEND_DATA);
             });
+
+            if ($template_id !== null) {
+                $this->html('');
+            }
         }
 
         return $this;


### PR DESCRIPTION
API instructions code sample in template page (https://app.mailersend.com/templates/xxxxx/edit) returning in Mailable only following:

`
return $this->mailersend('ynrw7gy7kog2k8e3', $variables);
`

But it's not possible to send mailable without View or HTML.
We can set HTML to an empty string to allow such behavior.