### PR TITLE
Fix default Laravel replyTo name null

### DIFF
--- a/src/MailerSendTransport.php
+++ b/src/MailerSendTransport.php
@@ -70,7 +70,7 @@ class MailerSendTransport implements TransportInterface
             ->setFrom($fromEmail)
             ->setFromName($fromName)
             ->setReplyTo($replyToEmail)
-            ->setReplyToName($replyToName)
+            ->setReplyToName(strval($replyToName))
             ->setRecipients($to)
             ->setCc($cc)
             ->setBcc($bcc)


### PR DESCRIPTION
As you can see in [Illuminate/Notifications/Messages/MailMessage::replyTo](https://github.com/laravel/framework/blob/10.x/src/Illuminate/Notifications/Messages/MailMessage.php#L196) Laravel's default ReplyTo Name is a "null" that causes error as MailerSend\Helpers\Builder\EmailParams::setReplyToName expects a string.