### PR TITLE
Laravel Mail Failover Configuration Enhancement

### DIFF
--- a/src/MailerSendTransport.php
+++ b/src/MailerSendTransport.php
@@ -2,12 +2,14 @@
 
 namespace MailerSend\LaravelDriver;
 
+use MailerSend\Exceptions\MailerSendException;
 use MailerSend\Helpers\Builder\Attachment;
 use MailerSend\Helpers\Builder\EmailParams;
 use MailerSend\Helpers\Builder\Recipient;
 use MailerSend\MailerSend;
 use Psr\Http\Message\ResponseInterface;
 use Symfony\Component\Mailer\Envelope;
+use Symfony\Component\Mailer\Exception\TransportException;
 use Symfony\Component\Mailer\Exception\TransportExceptionInterface;
 use Symfony\Component\Mailer\SentMessage;
 use Symfony\Component\Mailer\Transport\TransportInterface;
@@ -43,62 +45,66 @@ class MailerSendTransport implements TransportInterface
      */
     public function send(RawMessage $message, Envelope $envelope = null): ?SentMessage
     {
-        ['email' => $fromEmail, 'name' => $fromName] = $this->getFrom($message);
-        ['email' => $replyToEmail, 'name' => $replyToName] = $this->getReplyTo($message);
+        try {
+            ['email' => $fromEmail, 'name' => $fromName] = $this->getFrom($message);
+            ['email' => $replyToEmail, 'name' => $replyToName] = $this->getReplyTo($message);
 
-        $text = $message->getTextBody();
-        $html = $message->getHtmlBody();
+            $text = $message->getTextBody();
+            $html = $message->getHtmlBody();
 
-        $to = $this->getRecipients('to', $message);
-        $cc = $this->getRecipients('cc', $message);
-        $bcc = $this->getRecipients('bcc', $message);
+            $to = $this->getRecipients('to', $message);
+            $cc = $this->getRecipients('cc', $message);
+            $bcc = $this->getRecipients('bcc', $message);
 
-        $subject = $message->getSubject();
+            $subject = $message->getSubject();
 
-        $attachments = $this->getAttachments($message);
+            $attachments = $this->getAttachments($message);
 
-        [
-            'template_id' => $template_id,
-            'variables' => $variables,
-            'tags' => $tags,
-            'personalization' => $personalization,
-            'precedence_bulk_header' => $precedenceBulkHeader,
-            'send_at' => $sendAt,
-        ] = $this->getAdditionalData($message);
+            [
+                'template_id' => $template_id,
+                'variables' => $variables,
+                'tags' => $tags,
+                'personalization' => $personalization,
+                'precedence_bulk_header' => $precedenceBulkHeader,
+                'send_at' => $sendAt,
+            ] = $this->getAdditionalData($message);
 
-        $emailParams = app(EmailParams::class)
-            ->setFrom($fromEmail)
-            ->setFromName($fromName)
-            ->setReplyTo($replyToEmail)
-            ->setReplyToName(strval($replyToName))
-            ->setRecipients($to)
-            ->setCc($cc)
-            ->setBcc($bcc)
-            ->setSubject($subject)
-            ->setHtml($html)
-            ->setText($text)
-            ->setTemplateId($template_id)
-            ->setVariables($variables)
-            ->setPersonalization($personalization)
-            ->setAttachments($attachments)
-            ->setTags($tags)
-            ->setPrecedenceBulkHeader($precedenceBulkHeader)
-            ->setSendAt($sendAt);
+            $emailParams = app(EmailParams::class)
+                ->setFrom($fromEmail)
+                ->setFromName($fromName)
+                ->setReplyTo($replyToEmail)
+                ->setReplyToName(strval($replyToName))
+                ->setRecipients($to)
+                ->setCc($cc)
+                ->setBcc($bcc)
+                ->setSubject($subject)
+                ->setHtml($html)
+                ->setText($text)
+                ->setTemplateId($template_id)
+                ->setVariables($variables)
+                ->setPersonalization($personalization)
+                ->setAttachments($attachments)
+                ->setTags($tags)
+                ->setPrecedenceBulkHeader($precedenceBulkHeader)
+                ->setSendAt($sendAt);
 
-        $response = $this->mailersend->email->send($emailParams);
+            $response = $this->mailersend->email->send($emailParams);
 
-        /** @var ResponseInterface $respInterface */
-        $respInterface = $response['response'];
+            /** @var ResponseInterface $respInterface */
+            $respInterface = $response['response'];
 
-        if ($messageId = $respInterface->getHeaderLine('X-Message-Id')) {
-            $message->getHeaders()?->addTextHeader('X-MailerSend-Message-Id', $messageId);
+            if ($messageId = $respInterface->getHeaderLine('X-Message-Id')) {
+                $message->getHeaders()?->addTextHeader('X-MailerSend-Message-Id', $messageId);
+            }
+
+            if ($body = $respInterface->getBody()->getContents()) {
+                $message->getHeaders()?->addTextHeader('X-MailerSend-Body', $body);
+            }
+
+            return new SentMessage($message, $envelope);
+        } catch (MailersendException $exception) {
+            throw new TransportException($exception->getMessage(), $exception->getCode());
         }
-
-        if ($body = $respInterface->getBody()->getContents()) {
-            $message->getHeaders()?->addTextHeader('X-MailerSend-Body', $body);
-        }
-
-        return new SentMessage($message, $envelope);
     }
 
     protected function getFrom(RawMessage $message): array


### PR DESCRIPTION
Issue: #44 

Changes:
- Throw `TransportException` instead of `MailersendException` in order to support Failover config

## Description:

Laravel offers a valuable feature known as failover configuration for its mail drivers, allowing for seamless handling in case of failure during email transmission. This feature ensures that if one mail driver encounters an issue, Laravel automatically retries the transmission using the next registered driver.

### Documentation Reference:
[Laravel Documentation: Failover Configuration](https://laravel.com/docs/10.x/mail#failover-configuration)

### Current Issue with MailerSend Integration
However, this failover mechanism currently does not function as expected when utilizing MailerSend as the mail driver. The underlying reason for this limitation lies in the discrepancy between Laravel's failover mechanism and MailerSend's exception handling.

### Technical Details:
Symfony's Mail Transport component, which Laravel utilizes internally, relies on the `TransportExceptionInterface` to catch exceptions during email transmission. However, MailerSend diverges from this standard by throwing `MailerSendException` instances when encountering errors during transmission.

### Source Reference:
[Symfony Mailer: RoundRobinTransport](https://github.com/symfony/mailer/blob/7.0/Transport/RoundRobinTransport.php#L56-L60)

### Proposed Solution
To address this limitation and ensure seamless failover functionality with MailerSend, we propose a modification to throw `TransportException` instead of `MailerSendException` when errors occur during transmission. This adjustment aligns MailerSend's exception handling with Symfony's Mail Transport component, enabling Laravel's failover mechanism to properly detect and respond to transmission errors.