### PR TITLE
Allow merging config from Laravel mailer config

### DIFF
--- a/src/LaravelDriverServiceProvider.php
+++ b/src/LaravelDriverServiceProvider.php
@@ -11,8 +11,8 @@ class LaravelDriverServiceProvider extends ServiceProvider
 {
     public function boot()
     {
-        $this->app->make(MailManager::class)->extend('mailersend', function () {
-            $config = $this->app['config']->get('mailersend-driver', []);
+        $this->app->make(MailManager::class)->extend('mailersend', function (array $config) {
+            $config = array_merge($this->app['config']->get('mailersend-driver', []), $config);
 
             $mailersend = new MailerSend([
                 'api_key' => Arr::get($config, 'api_key'),


### PR DESCRIPTION
Every other mailer transport can have multiple instances in Laravel. This change is to allow for that.

Example:
```php
'mailers' => [
    'mailersend' => [ 
        'transport' => 'mailersend',
        'api_key' => 'prod-key',     
    ],
    'mailersend-staging' => [ 
        'transport' => 'mailersend',
        'api_key' => 'staging-key',     
    ],
]
```