### PR TITLE
fix: specifically marked nullable arguments as nullable type.

### DIFF
--- a/src/MailerSendTrait.php
+++ b/src/MailerSendTrait.php
@@ -11,11 +11,11 @@ use Symfony\Component\Mime\Part\DataPart;
 trait MailerSendTrait
 {
     public function mailersend(
-        string $template_id = null,
+        ?string $template_id = null,
         array $tags = [],
         array $personalization = [],
         ?bool $precedenceBulkHeader = null,
-        Carbon $sendAt = null
+        ?Carbon $sendAt = null
     ): static {
         if ($this instanceof Mailable && $this->driver() === 'mailersend') {
             $this->withSymfonyMessage(function (Email $message) use (

--- a/src/MailerSendTransport.php
+++ b/src/MailerSendTransport.php
@@ -42,7 +42,7 @@ class MailerSendTransport implements TransportInterface
      * @throws TransportExceptionInterface
      * @throws \MailerSend\Exceptions\MailerSendAssertException
      */
-    public function send(RawMessage $message, Envelope $envelope = null): ?SentMessage
+    public function send(RawMessage $message, ?Envelope $envelope = null): ?SentMessage
     {
         try{
             ['email' => $fromEmail, 'name' => $fromName] = $this->getFrom($message);


### PR DESCRIPTION
PHP 8.1+ does not like arguments that default to null but are not specified as nullable types.

This PR addresses this issue in the `MailerSendTrait`.

The errors being addressed are 

```
PHP Deprecated: MailerSend\LaravelDriver\MailerSendTrait::mailersend(): Implicitly marking parameter $sendAt as nullable is deprecated, the explicit nullable type must be used instead in vendor/mailersend/laravel-driver/src/MailerSendTrait.php on line 13
```

```
PHP Deprecated: MailerSend\LaravelDriver\MailerSendTrait::mailersend(): Implicitly marking parameter $template_id as nullable is deprecated, the explicit nullable type must be used instead in vendor/mailersend/laravel-driver/src/MailerSendTrait.php on line 13
```

```
PHP Deprecated: MailerSend\LaravelDriver\MailerSendTransport::send(): Implicitly marking parameter $envelope as nullable is deprecated, the explicit nullable type must be used instead in vendor/mailersend/laravel-driver/src/MailerSendTransport.php on line 45
```
