### PR TITLE
[SS] feature/sre-10189/switch-setup-php

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -20,7 +20,7 @@ jobs:
     - uses: actions/checkout@v6
 
     - name: Setup PHP
-      uses: shivammathur/setup-php@v2
+      uses: setup-php/setup-php@46ae35f3338b644fa11efcbbcd5d739c34372ae8
       with:
         php-version: ${{ matrix.php-versions }}
         extensions: mbstring, pdo, pdo_mysql, intl, zip


### PR DESCRIPTION


```diff
diff --git a/.github/workflows/php.yml b/.github/workflows/php.yml
index 5063f95dadab038f902c9ccb0b92efdf7d8bf669..e07c84840760ad9f5e6253242b90dc65f9f1bb9e 100644
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -20,7 +20,7 @@     steps:
     - uses: actions/checkout@v6
 
     - name: Setup PHP
-      uses: shivammathur/setup-php@v2
+      uses: setup-php/setup-php@46ae35f3338b644fa11efcbbcd5d739c34372ae8
       with:
         php-version: ${{ matrix.php-versions }}
         extensions: mbstring, pdo, pdo_mysql, intl, zip

```